### PR TITLE
Allow VPC instance to associate withi non-EIP public IP on launch.

### DIFF
--- a/lib/aerosol/launch_configuration.rb
+++ b/lib/aerosol/launch_configuration.rb
@@ -3,16 +3,17 @@ class Aerosol::LaunchConfiguration
   include Dockly::Util::Logger::Mixin
 
   logger_prefix '[aerosol launch_configuration]'
-  aws_attribute :aws_identifier  => 'LaunchConfigurationName',
-                :ami             => 'ImageId',
-                :instance_type   => 'InstanceType',
-                :security_groups => 'SecurityGroups',
-                :user_data       => 'UserData',
-                :iam_role        => 'IamInstanceProfile',
-                :kernel_id       => 'KernelId',
-                :key_name        => 'KeyName',
-                :spot_price      => 'SpotPrice',
-                :created_time    => 'CreatedTime'
+  aws_attribute :aws_identifier              => 'LaunchConfigurationName',
+                :ami                         => 'ImageId',
+                :instance_type               => 'InstanceType',
+                :security_groups             => 'SecurityGroups',
+                :user_data                   => 'UserData',
+                :iam_role                    => 'IamInstanceProfile',
+                :kernel_id                   => 'KernelId',
+                :key_name                    => 'KeyName',
+                :spot_price                  => 'SpotPrice',
+                :created_time                => 'CreatedTime',
+                :associate_public_ip_address => 'AssociatePublicIpAddress'
 
   primary_key :aws_identifier
   default_value(:security_groups) { [] }
@@ -81,7 +82,8 @@ private
       'KeyName' => key_name,
       'SecurityGroups' => security_groups,
       'SpotPrice' => spot_price,
-      'UserData' => Aerosol::Util.strip_heredoc(user_data || '')
+      'UserData' => Aerosol::Util.strip_heredoc(user_data || ''),
+      'AssociatePublicIpAddress' => associate_public_ip_address
     }.reject { |k, v| v.nil? }
   end
 


### PR DESCRIPTION
@bfulton @nahiluhmot For instances in a public VPC subnet (using an IGW instead of a NAT instance) we need to allow public IP association on launch for Internet access.
