### PR TITLE
Add environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,31 @@ It will use the default of waiting 30 minutes for a deploy before failing, and f
 
 If the server you're deploying from is not behind the same restrictions a development machine is, add a local SSH connection.  The local connection will be used when generating commands for connecting to the instances.
 
+Environments
+------------
+
+An environment is a set of deploys that may be run in parallel.
+This can be useful if you, for example, want to deploy a load balancer at the same time you deploy your backend application.
+
+Options:
+
+- deploy - Add a deploy to this environment.
+
+A basic environment (assuming there is already a deploy named `:quick_app` and another named `:quick_app_worker`):
+
+```ruby
+env :staging do
+  deploy :quick_app
+  deploy :quick_app_worker
+end
+```
+
+To run these deploys, the following task can be run:
+
+```shell
+$ bundle exec rake aerosol:env:staging
+```
+
 Namespace
 ---------
 

--- a/lib/aerosol.rb
+++ b/lib/aerosol.rb
@@ -10,6 +10,7 @@ module Aerosol
   require 'aerosol/instance'
   require 'aerosol/connection'
   require 'aerosol/deploy'
+  require 'aerosol/env'
 
   attr_reader :deploy, :instance, :git_sha, :namespace
   attr_writer :load_file
@@ -45,7 +46,8 @@ module Aerosol
       :auto_scalings => Aerosol::AutoScaling.instances,
       :deploys => Aerosol::Deploy.instances,
       :launch_configurations => Aerosol::LaunchConfiguration.instances,
-      :sshs => Aerosol::Connection.instances
+      :sshs => Aerosol::Connection.instances,
+      :envs => Aerosol::Env.instances
     }
   end
 
@@ -53,7 +55,8 @@ module Aerosol
     :auto_scaling => Aerosol::AutoScaling,
     :deploy => Aerosol::Deploy,
     :launch_configuration => Aerosol::LaunchConfiguration,
-    :ssh => Aerosol::Connection
+    :ssh => Aerosol::Connection,
+    :env => Aerosol::Env
   }.each do |method, klass|
     define_method(method) do |sym, &block|
       if block.nil?
@@ -64,7 +67,7 @@ module Aerosol
     end
   end
 
-  [:auto_scalings, :deploys, :launch_configurations, :sshs].each do |method|
+  [:auto_scalings, :deploys, :launch_configurations, :sshs, :envs].each do |method|
     define_method(method) do
       inst[method]
     end
@@ -73,7 +76,7 @@ module Aerosol
   module_function :inst, :load_inst, :setup, :load_file, :load_file=,
                   :auto_scaling,  :launch_configuration,  :deploy,  :ssh, :git_sha,
                   :auto_scalings, :launch_configurations, :deploys, :sshs,
-                  :namespace
+                  :namespace, :env, :envs
 end
 
 require 'aerosol/runner'

--- a/lib/aerosol/env.rb
+++ b/lib/aerosol/env.rb
@@ -1,0 +1,6 @@
+# An environment is a set of deploys.
+class Aerosol::Env
+  include Dockly::Util::DSL
+
+  dsl_class_attribute :deploy, Aerosol::Deploy, type: Array
+end

--- a/lib/aerosol/rake_task.rb
+++ b/lib/aerosol/rake_task.rb
@@ -49,6 +49,14 @@ namespace :aerosol do
   all_deploy_tasks = []
   all_asynch_deploy_tasks = []
 
+  namespace :env do
+    Aerosol.envs.values.each do |env|
+      desc "Run all of the deploys for #{env.name} in parallel"
+      multitask env.name => env.deploy.map { |dep| "aerosol:#{dep.name}:all" }
+    end
+  end
+
+
   Aerosol.deploys.values.each do |inst|
     namespace :"#{inst.name}" do
       desc "Runs the ActiveRecord migration through the SSH connection given"

--- a/spec/aerosol/env_spec.rb
+++ b/spec/aerosol/env_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Aerosol::Env, :cur do
+  describe '#deploy' do
+    let(:name) { "unique_name_#{Time.now.to_i}".to_sym }
+    let!(:deploy) { Aerosol.deploy(name) { } }
+
+
+    it 'adds a deploy to the list of deploys' do
+      expect { subject.deploy(name) }
+        .to change { subject.deploy }
+        .from(nil)
+        .to([deploy])
+    end
+  end
+end


### PR DESCRIPTION
@tlunter @bfulton @adamjt 

This pull request adds supports for environments, which are simple a set of deploys. Below is the definition of an environment:

``` ruby
deploy :backend do
  ...
end

deploy :frontend do
   ...
end

deploy :load_balancer do
   ...
end

env :staging do
  deploy :backend
  deploy :frontend
  deploy :load_balancer
end
```

When an environment is defined, a multitask is also defined which will perform all of the deploys in that environment in parallel. Execute `bundle exec rake aerosol:env:staging` to run all deploys for the `:staging` environment in this example.

I'm thinking patch version bump for the next release.
