### PR TITLE
Support custom live checks

### DIFF
--- a/lib/aerosol/deploy.rb
+++ b/lib/aerosol/deploy.rb
@@ -33,6 +33,11 @@ class Aerosol::Deploy
     @live_check
   end
 
+  def is_alive?(&block)
+    @is_alive = block unless block.nil?
+    @is_alive
+  end
+
   def live_check_url
     [ssl ? 'https' : 'http', '://localhost:', app_port, live_check].join
   end

--- a/spec/aerosol/deploy_spec.rb
+++ b/spec/aerosol/deploy_spec.rb
@@ -168,4 +168,25 @@ describe Aerosol::Deploy do
       end
     end
   end
+
+  describe '#is_alive?' do
+    let(:check) { proc { true } }
+
+    context 'when no argument is given' do
+      before { subject.is_alive?(&check) }
+
+      it 'returns the current value of is_alive?' do
+        expect(subject.is_alive?).to eq(check)
+      end
+    end
+
+    context 'when an argument is given' do
+      it 'sets is_alive? to that value' do
+        expect { subject.is_alive?(&check) }
+          .to change { subject.is_alive? }
+          .from(nil)
+          .to(check)
+      end
+    end
+  end
 end

--- a/spec/aerosol/env_spec.rb
+++ b/spec/aerosol/env_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Aerosol::Env, :cur do
+describe Aerosol::Env do
   describe '#deploy' do
     let(:name) { "unique_name_#{Time.now.to_i}".to_sym }
     let!(:deploy) { Aerosol.deploy(name) { } }

--- a/spec/aerosol/runner_spec.rb
+++ b/spec/aerosol/runner_spec.rb
@@ -255,7 +255,7 @@ describe Aerosol::Runner do
       timeout = timeout_length
       Aerosol::Deploy.new! do
         name :wait_for_new_instances_deploy
-        live_check '/live_check'
+        is_alive? { is_site_live }
         instance_live_grace_period timeout
         stub(:sleep)
       end
@@ -273,6 +273,7 @@ describe Aerosol::Runner do
     context 'when all of the new instances eventually return a 200' do
       let(:timeout_length) { 1 }
       let(:healthy) { true }
+      let(:is_site_live) { true }
 
       it 'does nothing' do
         expect { action }.to_not raise_error
@@ -281,6 +282,7 @@ describe Aerosol::Runner do
 
     context 'when at least one of the instances never returns a 200' do
       let(:healthy) { false }
+      let(:is_site_live) { false }
 
       it 'raises an error' do
         expect { action }.to raise_error
@@ -289,6 +291,7 @@ describe Aerosol::Runner do
 
     context 'when getting new instances takes too long' do
       let(:healthy) { true }
+      let(:is_site_live) { false }
       before do
         allow(subject).to receive(:new_instances) { sleep 10 }
       end


### PR DESCRIPTION
@tlunter @bfulton 

Add support for arbitrary live commands via `Deploy#is_alive?`
