### PR TITLE
Remove duplicate privateIpAddress key.

### DIFF
--- a/lib/aerosol/auto_scaling.rb
+++ b/lib/aerosol/auto_scaling.rb
@@ -224,7 +224,6 @@ private
         'iamInstanceProfile'  => launch_configuration.iam_role,
         'networkInterfaces'   => [],
         'ownerId'             => nil,
-        'privateIpAddress'    => nil,
         'reservationId'       => Fog::AWS::Mock.reservation_id,
         'stateReason'         => {},
         'ipAddress'           => Fog::AWS::Mock.ip_address,


### PR DESCRIPTION
@tlunter @nahiluhmot Fixes `warning: duplicated key at line 231 ignored: "privateIpAddress"`