### PR TITLE
Allow user data to be passed as a Proc

### DIFF
--- a/aerosol.gemspec
+++ b/aerosol.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'grit'
   gem.add_dependency 'net-ssh'
   gem.add_dependency 'net-ssh-gateway'
-  gem.add_dependency 'dockly-util', '~> 0.0.5'
+  gem.add_dependency 'dockly-util', '~> 0.1.0'
   gem.add_development_dependency 'cane'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'

--- a/spec/aerosol/launch_configuration_spec.rb
+++ b/spec/aerosol/launch_configuration_spec.rb
@@ -424,4 +424,17 @@ describe Aerosol::LaunchConfiguration do
       end
     end
   end
+
+  describe '#meta_data' do
+    subject do
+      described_class.new do
+        name :my_launch_config
+        meta_data('Test' => '1')
+      end
+    end
+
+    it 'returns the hash' do
+      expect(subject.meta_data['Test']).to eq('1')
+    end
+  end
 end

--- a/spec/aerosol/launch_configuration_spec.rb
+++ b/spec/aerosol/launch_configuration_spec.rb
@@ -394,4 +394,34 @@ describe Aerosol::LaunchConfiguration do
       end
     end
   end
+
+  describe '#corrected_user_data' do
+    let(:encoded_user_data_string) { Base64.encode64('test') }
+
+    context 'when the user_data is a String' do
+      subject do
+        described_class.new do
+          name :corrected_user_data
+          user_data 'test'
+        end
+      end
+
+      it 'correctly encodes to base64' do
+        expect(subject.corrected_user_data).to eq(encoded_user_data_string)
+      end
+    end
+
+    context 'when the user_data is a Proc' do
+      subject do
+        described_class.new do
+          name :corrected_user_data_2
+          user_data { 'test' }
+        end
+      end
+
+      it 'correctly encodes to base64' do
+        expect(subject.corrected_user_data).to eq(encoded_user_data_string)
+      end
+    end
+  end
 end


### PR DESCRIPTION
@nahiluhmot

This will require a dockly-util version bump for block support: https://github.com/swipely/dockly-util/pull/8

This will let us lazily generate the user_data instead of doing it when building the LC, ASG, and deploy objects.