### PR TITLE
Replace grit with rugged.

### DIFF
--- a/aerosol.gemspec
+++ b/aerosol.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'clamp', '~> 0.6'
   gem.add_dependency 'excon'
   gem.add_dependency 'aws-sdk', '~> 2.0'
-  gem.add_dependency 'grit'
+  gem.add_dependency 'rugged', '~> 0.23.3'
   gem.add_dependency 'net-ssh'
   gem.add_dependency 'net-ssh-gateway'
   gem.add_dependency 'dockly-util', '~> 0.1.0'

--- a/lib/aerosol/runner.rb
+++ b/lib/aerosol/runner.rb
@@ -1,6 +1,5 @@
 require 'socket'
 require 'active_record'
-require 'grit'
 require 'timeout'
 
 class Aerosol::Runner

--- a/lib/aerosol/util.rb
+++ b/lib/aerosol/util.rb
@@ -1,4 +1,4 @@
-require 'grit'
+require 'rugged'
 
 module Aerosol::Util
   extend self
@@ -32,10 +32,10 @@ module Aerosol::Util
   end
 
   def git_repo
-    @git_repo ||= Grit::Repo.new('.')
+    @git_repo ||= Rugged::Repository.new('.')
   end
 
   def git_sha
-    @git_sha ||= git_repo.git.show.lines.first.chomp.match(/^commit ([a-f0-9]+)$/)[1][0..6] rescue 'unknown'
+    @git_sha ||= git_repo.last_commit.oid[0..6] rescue 'unknown'
   end
 end


### PR DESCRIPTION
@tlunter @nahiluhmot Grit is no longer maintained, and has a dependency on posix-spawn which does not work with jruby.