### PR TITLE
Use private IPs when interacting with instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: false
+dist: trusty
 language: ruby
 rvm:
     - 1.9.3
-    - 2.0.0
+    - 2.0
+    - 2.1
+    - 2.2
+cache: bundler
+before_install: gem install bundler
 script: CI=true bundle exec rake
-

--- a/lib/aerosol/instance.rb
+++ b/lib/aerosol/instance.rb
@@ -25,7 +25,7 @@ class Aerosol::Instance
   end
 
   def address
-    if launch_configuration.always_use_private_address || public_hostname.blank?
+    if launch_configuration.try(:always_use_private_address) || public_hostname.blank?
       private_ip_address
     else
       public_hostname

--- a/lib/aerosol/instance.rb
+++ b/lib/aerosol/instance.rb
@@ -25,7 +25,7 @@ class Aerosol::Instance
   end
 
   def address
-    if public_hostname.blank?
+    if launch_configuration.always_use_private_address || public_hostname.blank?
       private_ip_address
     else
       public_hostname

--- a/lib/aerosol/instance.rb
+++ b/lib/aerosol/instance.rb
@@ -25,7 +25,7 @@ class Aerosol::Instance
   end
 
   def address
-    if launch_configuration.try(:always_use_private_address) || public_hostname.blank?
+    if launch_configuration.always_use_private_address || public_hostname.blank?
       private_ip_address
     else
       public_hostname

--- a/lib/aerosol/launch_configuration.rb
+++ b/lib/aerosol/launch_configuration.rb
@@ -5,12 +5,13 @@ class Aerosol::LaunchConfiguration
   logger_prefix '[aerosol launch_configuration]'
   aws_attribute :launch_configuration_name, :image_id, :instance_type, :security_groups, :user_data,
                 :iam_instance_profile, :kernel_id, :key_name, :spot_price, :created_time,
-                :associate_public_ip_address
+                :associate_public_ip_address, :always_use_private_address
   dsl_attribute :meta_data
 
   primary_key :launch_configuration_name
   default_value(:security_groups) { [] }
   default_value(:meta_data) { {} }
+  default_value(:always_use_private_address) { false }
 
   def launch_configuration_name(arg = nil)
     if arg

--- a/spec/aerosol/auto_scaling_spec.rb
+++ b/spec/aerosol/auto_scaling_spec.rb
@@ -485,25 +485,29 @@ describe Aerosol::AutoScaling do
           availability_zone: 'us-east-1a',
           lifecycle_state: 'InService',
           health_status: 'GOOD',
-          launch_configuration_name: launch_configuration.name.to_s
+          launch_configuration_name: launch_configuration.name.to_s,
+          protected_from_scale_in: false
         }, {
           instance_id: 'i-1239014',
           availability_zone: 'us-east-1a',
           lifecycle_state: 'InService',
           health_status: 'GOOD',
-          launch_configuration_name: launch_configuration.name.to_s
+          launch_configuration_name: launch_configuration.name.to_s,
+          protected_from_scale_in: false
         }, {
           instance_id: 'i-1239015',
           availability_zone: 'us-east-1a',
           lifecycle_state: 'InService',
           health_status: 'GOOD',
-          launch_configuration_name: launch_configuration.name.to_s
+          launch_configuration_name: launch_configuration.name.to_s,
+          protected_from_scale_in: false
         }, {
           instance_id: 'i-1239016',
           availability_zone: 'us-east-1a',
           lifecycle_state: 'InService',
           health_status: 'GOOD',
-          launch_configuration_name: launch_configuration.name.to_s
+          launch_configuration_name: launch_configuration.name.to_s,
+          protected_from_scale_in: false
         }]
       }]
     }

--- a/spec/aerosol/connection_spec.rb
+++ b/spec/aerosol/connection_spec.rb
@@ -40,7 +40,8 @@ describe Aerosol::Connection do
 
       context 'when the host is an instance' do
         let(:public_hostname) { nil }
-        let(:host) { Aerosol::Instance.new }
+        let(:launch_configuration) { Aerosol::LaunchConfiguration.new!(name: :test_lc) }
+        let(:host) { Aerosol::Instance.new(launch_configuration: launch_configuration.name) }
         subject do
           Aerosol::Connection.new.tap do |inst|
             inst.name :connection_for_tim_horton
@@ -72,7 +73,8 @@ describe Aerosol::Connection do
 
       context 'when the host is passed into with_connection' do
         let(:public_hostname) { nil }
-        let(:host) { Aerosol::Instance.new }
+        let(:launch_configuration) { Aerosol::LaunchConfiguration.new!(name: :test_lc) }
+        let(:host) { Aerosol::Instance.new(launch_configuration: launch_configuration.name) }
         subject do
           Aerosol::Connection.new.tap do |inst|
             inst.name :connection_for_tim_horton

--- a/spec/aerosol/deploy_spec.rb
+++ b/spec/aerosol/deploy_spec.rb
@@ -113,7 +113,8 @@ describe Aerosol::Deploy do
 
   describe '#generate_ssh_command' do
     let(:ssh_ref) { double(:ssh_ref) }
-    let(:instance) { Aerosol::Instance.new }
+    let(:launch_configuration) { Aerosol::LaunchConfiguration.new!(name: :test_lc) }
+    let(:instance) { Aerosol::Instance.new(launch_configuration: launch_configuration.name) }
     let(:ssh_command) { subject.generate_ssh_command(instance) }
 
     before do

--- a/spec/aerosol/instance_spec.rb
+++ b/spec/aerosol/instance_spec.rb
@@ -26,7 +26,8 @@ describe Aerosol::Instance do
               lifecycle_state: 'InService',
               health_status: 'GOOD',
               launch_configuration_name: launch_configuration.launch_configuration_name.to_s,
-              auto_scaling_group_name: "test-#{i}"
+              auto_scaling_group_name: "test-#{i}",
+              protected_from_scale_in: false
             }
           end
         })
@@ -49,7 +50,8 @@ describe Aerosol::Instance do
             lifecycle_state: 'InService',
             health_status: 'GOOD',
             launch_configuration_name: launch_configuration.launch_configuration_name.to_s,
-            auto_scaling_group_name: 'test'
+            auto_scaling_group_name: 'test',
+            protected_from_scale_in: false
           }
         ]
       })

--- a/spec/aerosol/runner_spec.rb
+++ b/spec/aerosol/runner_spec.rb
@@ -186,7 +186,8 @@ describe Aerosol::Runner do
             launch_configuration_name: "launch_config-#{i+1}",
             availability_zone: 'us-east-1a',
             lifecycle_state: 'InService',
-            health_status: 'Healthy'
+            health_status: 'Healthy',
+            protected_from_scale_in: false
           }
         end,
         next_token: nil
@@ -524,7 +525,8 @@ describe Aerosol::Runner do
             auto_scaling_group_name: 'stop_app_launch_config-123456',
             availability_zone: 'us-east-1a',
             lifecycle_state: 'InService',
-            health_status: 'Running'
+            health_status: 'Running',
+            protected_from_scale_in: false
           }
         end
       })


### PR DESCRIPTION
If a subnet requests a public IP address, but we still want to interact over private IPs, enable this.