### PR TITLE
Support launch_template deploys

### DIFF
--- a/lib/aerosol/auto_scaling.rb
+++ b/lib/aerosol/auto_scaling.rb
@@ -156,6 +156,12 @@ class Aerosol::AutoScaling
 }}
   end
 
+  def self.from_hash(hash)
+    instance = super(hash)
+    instance['launch_template'] = (hash[:launch_template][:launch_template_name]) if hash[:launch_template]
+    instance
+  end
+
 private
   def conn
     Aerosol::AWS.auto_scaling

--- a/lib/aerosol/aws_model.rb
+++ b/lib/aerosol/aws_model.rb
@@ -5,6 +5,7 @@ module Aerosol::AWSModel
       extend ClassMethods
 
       attr_accessor :from_aws
+      attr_accessor :launch_template
     end
   end
 
@@ -76,6 +77,7 @@ module Aerosol::AWSModel
 
       instance = new!
       instance.from_aws = true
+      instance.launch_template = hash[:launch_template][:launch_template_name] if hash[:launch_template]
 
       aws_attributes.each { |attr| instance.send(attr, hash[attr]) unless hash[attr].nil? }
       refs.each { |name, inst| instance.send(name, inst.name) }

--- a/lib/aerosol/aws_model.rb
+++ b/lib/aerosol/aws_model.rb
@@ -5,7 +5,6 @@ module Aerosol::AWSModel
       extend ClassMethods
 
       attr_accessor :from_aws
-      attr_accessor :launch_template
     end
   end
 
@@ -77,7 +76,6 @@ module Aerosol::AWSModel
 
       instance = new!
       instance.from_aws = true
-      instance.launch_template = hash[:launch_template][:launch_template_name] if hash[:launch_template]
 
       aws_attributes.each { |attr| instance.send(attr, hash[attr]) unless hash[attr].nil? }
       refs.each { |name, inst| instance.send(name, inst.name) }

--- a/lib/aerosol/instance.rb
+++ b/lib/aerosol/instance.rb
@@ -59,6 +59,12 @@ class Aerosol::Instance
     instances
   end
 
+  def self.from_hash(hash)
+    instance = super(hash)
+    instance['launch_template'] = (hash[:launch_template][:launch_template_name]) if hash[:launch_template]
+    instance
+  end
+
 private
   def describe!
     ensure_present! :instance_id

--- a/lib/aerosol/instance.rb
+++ b/lib/aerosol/instance.rb
@@ -5,6 +5,7 @@ class Aerosol::Instance
 
   aws_attribute :availability_zone, :health_status, :instance_id, :lifecycle_state
   aws_class_attribute :launch_configuration, Aerosol::LaunchConfiguration
+  aws_class_attribute :launch_template, Aerosol::LaunchTemplate
   primary_key :instance_id
 
   def live?

--- a/lib/aerosol/launch_template.rb
+++ b/lib/aerosol/launch_template.rb
@@ -60,7 +60,7 @@ class Aerosol::LaunchTemplate
   def all_instances
     Aerosol::Instance.all.select { |instance|
       !instance.launch_template.nil? &&
-        (instance.launch_template.launch_template == launch_template_name)
+        (instance.launch_template == launch_template_name)
     }.each(&:description)
   end
 


### PR DESCRIPTION
Since the `launch_template_name` is in the `launch_template`, the `from_hash` wasn't grabbing the `launch_template_name`. This led to deploys stalling since `aerosol` couldn't find the instances.